### PR TITLE
nick/11 Added assign pr owner github action and a codeowner file

### DIFF
--- a/.github/workflows/auto-assign-pr-owner.yml
+++ b/.github/workflows/auto-assign-pr-owner.yml
@@ -1,0 +1,2 @@
+- name: Auto assign owner
+uses: DanielSwensson/auto-assign-owner-action@v1.0.6

--- a/docs/CODEOWNERS.txt
+++ b/docs/CODEOWNERS.txt
@@ -1,0 +1,8 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @nmurphy101 @AchingDarsho @Bluuuke @SilentSand7 will be requested for
+# review when someone opens a pull request.
+*       @nmurphy101 @AchingDarsho @Bluuuke @SilentSand7


### PR DESCRIPTION
This will allow us the ability to auto assign reviewers to PR's and auto assign the "Assignee" to the PR creator.